### PR TITLE
Add additional link, license info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ There are lots of examples of researchers constructing self-similarity matrices 
 - unzip
 - run pngify.sh
 - move pngs to public/img/gallery (or wherever else they're needed)
+
+### Demo
+
+[View demo at https://colinmorris.github.io/SongSim](https://colinmorris.github.io/SongSim)
+
+### License
+
+MIT


### PR DESCRIPTION
It wasn't apparent to me that the H1 was a link. Added demo link so nobody else misses it.

Also added basic license info to save a click.